### PR TITLE
fix yincrease bug: inRangeRestartSkew += lastValue

### DIFF
--- a/promql/functions.go
+++ b/promql/functions.go
@@ -255,7 +255,7 @@ func yIncrease(points []Point, rangeStartMsec, rangeEndMsec int64, isCounter boo
 		if point.T >= rangeStartMsec {
 			if isCounter &&
 				point.V < lastValue { // If counter went backwards, it must have been a counter reset on process restart.
-				inRangeRestartSkew += point.V
+				inRangeRestartSkew += lastValue
 			}
 		} else {
 			lastBeforeRange = point.V

--- a/promql/test.go
+++ b/promql/test.go
@@ -326,7 +326,7 @@ func (cmd *loadCmd) append(a storage.Appender) error {
 		m := cmd.metrics[h]
 
 		for _, s := range smpls {
-			if _, err := a.Append(0, m, s.T + scrapeOffsetMsec, s.V); err != nil {
+			if _, err := a.Append(0, m, s.T+scrapeOffsetMsec, s.V); err != nil {
 				return err
 			}
 		}

--- a/promql/testdata/functions.test
+++ b/promql/testdata/functions.test
@@ -249,32 +249,32 @@ clear
 # Tests for increase()/xincrease()/xrate()/yincrease()/yrate().
 load 5s
 	http_requests{path="/foo"}	1000+10x10
-	http_requests{path="/bar"}	2000+10x5 2000+10x4
+	http_requests{path="/bar"}	2000+10x5 5+10x4
 
 # Tests for increase().
 eval instant at 50s increase(http_requests[50s])
 	{path="/foo"} 100
-	{path="/bar"} 2311.1111111111113
+	{path="/bar"} 94.44444444444444
 
 eval instant at 50s xincrease(http_requests[50s])
 	{path="/foo"} 90
-	{path="/bar"} 2080
+	{path="/bar"} 85
 
 eval instant at 50s yincrease(http_requests[50s])
 	{path="/foo"} 1090
-	{path="/bar"} 4030
+	{path="/bar"} 2085
 
 eval instant at 50s increase(http_requests[100s])
 	{path="/foo"} 104.358
-	{path="/bar"} 2411.829333333333
+	{path="/bar"} 98.56033333333333
 
 eval instant at 50s xincrease(http_requests[100s])
 	{path="/foo"} 90
-	{path="/bar"} 2080
+	{path="/bar"} 85
 
 eval instant at 50s yincrease(http_requests[100s])
 	{path="/foo"} 1090
-	{path="/bar"} 4030
+	{path="/bar"} 2085
 
 # eval instant at 50s increase(http_requests[5s])
 # 	{path="/foo"} 10
@@ -301,19 +301,19 @@ eval instant at 49s xincrease(http_requests[3s])
 # Tests for xrate().
 eval instant at 50s xrate(http_requests[50s])
 	{path="/foo"} 1.8
-	{path="/bar"} 41.6
+	{path="/bar"} 1.7
 
 eval instant at 50s yrate(http_requests[50s])
 	{path="/foo"} 21.8
-	{path="/bar"} 80.6
+	{path="/bar"} 41.7
 
 eval instant at 50s xrate(http_requests[100s])
 	{path="/foo"} 0.9
-	{path="/bar"} 20.8
+	{path="/bar"} 0.85
 
 eval instant at 50s yrate(http_requests[100s])
 	{path="/foo"} 10.9
-	{path="/bar"} 40.3
+	{path="/bar"} 20.85
 
 eval instant at 50s xrate(http_requests[5s])
 	{path="/foo"} 2
@@ -341,19 +341,54 @@ clear
 
 # Test for increase()/xincrease()/yincrease() with counter reset.
 # When the counter is reset, it always starts at 0.
-# So the sequence 1003 1002 (decreasing counter = reset) is interpreted the same as 1003 1000 1001 1002.
-# Prometheus assumes it missed the intermediate values 1000 and 1001.
+# So the sequence 1003 2 (decreasing counter = reset) is interpreted the same as 1003 0 1 2.
+# Prometheus assumes it missed the intermediate values 0 and 1.
 load 5m
-	http_requests{path="/foo"}	1000 1001 1002 1003 1002 1003 1004
+	http_requests{path="/foo"}	1000 1001 1003 1006 4 9 16
 
 eval instant at 30m increase(http_requests[30m])
-	{path="/foo"} 1207.2
+	{path="/foo"} 18
 
 eval instant at 30m xincrease(http_requests[30m])
-	{path="/foo"} 1006
+	{path="/foo"} 15
 
 eval instant at 30m yincrease(http_requests[30m])
-	{path="/foo"} 2005
+	{path="/foo"} 1015
+
+# Test counter reset at the range boundary.
+
+eval instant at 20m xincrease(http_requests[5m])
+	{path="/foo"} 3
+
+eval instant at 20m yincrease(http_requests[5m])
+	{path="/foo"} 3
+
+
+eval instant at 20m increase(http_requests[10m])
+	{path="/foo"} 6
+
+eval instant at 20m xincrease(http_requests[10m])
+	{path="/foo"} 5
+
+eval instant at 20m yincrease(http_requests[10m])
+	{path="/foo"} 5
+
+
+eval instant at 25m xincrease(http_requests[5m])
+	{path="/foo"} 4
+
+eval instant at 25m yincrease(http_requests[5m])
+	{path="/foo"} 4
+
+
+eval instant at 25m increase(http_requests[10m])
+	{path="/foo"} 8
+
+eval instant at 25m xincrease(http_requests[10m])
+	{path="/foo"} 7
+
+eval instant at 25m yincrease(http_requests[10m])
+	{path="/foo"} 7
 
 clear
 


### PR DESCRIPTION
This fixes the counter reset bug that @ttstarck found [here](https://invoca.slack.com/archives/CTJ586T0U/p1683242845593229?thread_ts=1683241729.525169&cid=CTJ586T0U).

I added a full suite of tests that check the reset values across 1 and 2 samples. (`increase` can't measure across 1 sample, so I skipped those cases.)

BTW, the fix brings `yincrease` in line with `xincrease`'s implementation [here](https://github.com/Invoca/prometheus/blob/invoca-2.35.0-extensions/promql/functions.go#L179). That checks out in the test results as well.