### PR TITLE
Invoca 2.38.0/fix replace rate funcs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -48,7 +48,6 @@ require (
 	github.com/prometheus/exporter-toolkit v0.7.1
 	github.com/scaleway/scaleway-sdk-go v1.0.0-beta.9
 	github.com/shurcooL/httpfs v0.0.0-20190707220628-8d4bc4ba7749
-	github.com/sirupsen/logrus v1.8.1 // indirect
 	github.com/stretchr/testify v1.8.0
 	github.com/vultr/govultr/v2 v2.17.2
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.34.0

--- a/promql/engine.go
+++ b/promql/engine.go
@@ -1832,8 +1832,8 @@ func (ev *evaluator) matrixSelector(node *parser.MatrixSelector) (Matrix, storag
 // values). Any such points falling before mint are discarded; points that fall
 // into the [mint, maxt] range are retained; only points with later timestamps
 // are populated from the iterator.
-//** mint, maxt are min timestamp and max timestamp for this slice, in milliseconds
-//** TODO: rename them minTs and maxTs
+// ** mint, maxt are min timestamp and max timestamp for this slice, in milliseconds
+// ** TODO: rename them minTs and maxTs
 func (ev *evaluator) matrixIterSlice(it *storage.BufferedSeriesIterator, mint, maxt int64, extRange bool, out []Point) []Point {
 	//** Drop any samples at the front that we don't need.
 	var dropBefore int

--- a/promql/functions.go
+++ b/promql/functions.go
@@ -1403,15 +1403,15 @@ func init() {
 	}
 }
 
-func copyParserFunction(from_name, to_name string) {
-	fromFunction := *parser.Functions[from_name]
-	fromFunction.Name = to_name
-	parser.Functions[to_name] = &fromFunction
+func copyParserFunction(fromName, toName string) {
+	fromFunction := *parser.Functions[fromName]
+	fromFunction.Name = toName
+	parser.Functions[toName] = &fromFunction
 }
 
-func repointFunction(name, new_name, orig_name string) {
-	FunctionCalls[orig_name] = FunctionCalls[name]
-	FunctionCalls[name] = FunctionCalls[new_name]
+func repointFunction(name, newName, origName string) {
+	FunctionCalls[origName] = FunctionCalls[name]
+	FunctionCalls[name] = FunctionCalls[newName]
 }
 
 type vectorByValueHeap Vector

--- a/promql/functions.go
+++ b/promql/functions.go
@@ -230,7 +230,8 @@ func debugSampleString(points []Point) string {
 //
 // It is a linear function, meaning that for adjacent periods p0 and p1
 // ("adjacent" means p0's rangeEndMsec == p1's rangeStartMsec):
-//   yIncrease(p0) + yIncrease(p1) == yIncrease(p0 + p1)
+//
+//	yIncrease(p0) + yIncrease(p1) == yIncrease(p0 + p1)
 func yIncrease(points []Point, rangeStartMsec, rangeEndMsec int64, isCounter bool) float64 {
 	log.Printf("yIncrease: range: %.3f...%.3f\n", float64(rangeStartMsec)/1000.0, float64(rangeEndMsec)/1000.0)
 	log.Println("yIncrease: samples: ", debugSampleString(points))
@@ -1379,20 +1380,38 @@ func init() {
 		delete(parser.Functions, "xincrease")
 		delete(parser.Functions, "xrate")
 		fmt.Println("Successfully replaced rate & friends with xrate & friends (and removed xrate & friends function keys).")
-	case "2":
-		FunctionCalls["delta"] = FunctionCalls["ydelta"]
-		parser.Functions["delta"] = parser.Functions["ydelta"]
-		parser.Functions["delta"].Name = "delta"
 
-		FunctionCalls["increase"] = FunctionCalls["yincrease"]
-		parser.Functions["increase"] = parser.Functions["yincrease"]
-		parser.Functions["increase"].Name = "increase"
+	case "x", "X":
+		copyParserFunction("delta", "orig_delta")
+		copyParserFunction("increase", "orig_increase")
+		copyParserFunction("rate", "orig_rate")
+		repointFunction("delta", "xdelta", "orig_delta")
+		repointFunction("increase", "xincrease", "orig_increase")
+		repointFunction("rate", "xrate", "orig_rate")
 
-		FunctionCalls["rate"] = FunctionCalls["yrate"]
-		parser.Functions["rate"] = parser.Functions["yrate"]
-		parser.Functions["rate"].Name = "rate"
-		fmt.Println("Successfully replaced rate/increase/delta with yrate/yincrease/ydelta (and left the latter names available as well).")
+		fmt.Println("Successfully replaced rate/increase/delta with xrate/xincrease/xdelta (and left the latter names available as well, and original functions callable as orig_rate/orig_increase/orig_delta).")
+
+	case "2", "y", "Y":
+		copyParserFunction("delta", "orig_delta")
+		copyParserFunction("increase", "orig_increase")
+		copyParserFunction("rate", "orig_rate")
+		repointFunction("delta", "ydelta", "orig_delta")
+		repointFunction("increase", "yincrease", "orig_increase")
+		repointFunction("rate", "yrate", "orig_rate")
+
+		fmt.Println("Successfully replaced rate/increase/delta with yrate/yincrease/ydelta (and left the latter names available as well, and original functions callable as orig_rate/orig_increase/orig_delta).")
 	}
+}
+
+func copyParserFunction(from_name, to_name string) {
+	fromFunction := *parser.Functions[from_name]
+	fromFunction.Name = to_name
+	parser.Functions[to_name] = &fromFunction
+}
+
+func repointFunction(name, new_name, orig_name string) {
+	FunctionCalls[orig_name] = FunctionCalls[name]
+	FunctionCalls[name] = FunctionCalls[new_name]
 }
 
 type vectorByValueHeap Vector


### PR DESCRIPTION
- Same SHAs from https://github.com/Invoca/prometheus/pull/5, cherry-picked here to a 2.38.0 base.