### PR TITLE
Invoca 2.35.0/fix replace rate funcs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -54,7 +54,6 @@ require (
 	github.com/prometheus/exporter-toolkit v0.7.1
 	github.com/scaleway/scaleway-sdk-go v1.0.0-beta.9
 	github.com/shurcooL/httpfs v0.0.0-20190707220628-8d4bc4ba7749
-	github.com/sirupsen/logrus v1.8.1 // indirect
 	github.com/stretchr/testify v1.7.1
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.31.0
 	go.opentelemetry.io/otel v1.6.1

--- a/promql/engine.go
+++ b/promql/engine.go
@@ -1824,8 +1824,8 @@ func (ev *evaluator) matrixSelector(node *parser.MatrixSelector) (Matrix, storag
 // values). Any such points falling before mint are discarded; points that fall
 // into the [mint, maxt] range are retained; only points with later timestamps
 // are populated from the iterator.
-//** mint, maxt are min timestamp and max timestamp for this slice, in milliseconds
-//** TODO: rename them minTs and maxTs
+// ** mint, maxt are min timestamp and max timestamp for this slice, in milliseconds
+// ** TODO: rename them minTs and maxTs
 func (ev *evaluator) matrixIterSlice(it *storage.BufferedSeriesIterator, mint, maxt int64, extRange bool, out []Point) []Point {
 	//** Drop any samples at the front that we don't need.
 	var dropBefore int

--- a/promql/functions.go
+++ b/promql/functions.go
@@ -1401,15 +1401,15 @@ func init() {
 	}
 }
 
-func copyParserFunction(from_name, to_name string) {
-	fromFunction := *parser.Functions[from_name]
-	fromFunction.Name = to_name
-	parser.Functions[to_name] = &fromFunction
+func copyParserFunction(fromName, toName string) {
+	fromFunction := *parser.Functions[fromName]
+	fromFunction.Name = toName
+	parser.Functions[toName] = &fromFunction
 }
 
-func repointFunction(name, new_name, orig_name string) {
-	FunctionCalls[orig_name] = FunctionCalls[name]
-	FunctionCalls[name] = FunctionCalls[new_name]
+func repointFunction(name, newName, origName string) {
+	FunctionCalls[origName] = FunctionCalls[name]
+	FunctionCalls[name] = FunctionCalls[newName]
 }
 
 type vectorByValueHeap Vector


### PR DESCRIPTION
Same SHAs from https://github.com/Invoca/prometheus/pull/5, cherry-picked here to a 2.35.0 base.