### PR TITLE
Improve yIncrease performance

### DIFF
--- a/promql/functions.go
+++ b/promql/functions.go
@@ -16,7 +16,6 @@ package promql
 import (
 	"bytes"
 	"fmt"
-	"log"
 	"math"
 	"os"
 	"sort"
@@ -239,8 +238,9 @@ func debugSampleString(points []Point) string {
 //
 //	yIncrease(p0) + yIncrease(p1) == yIncrease(p0 + p1)
 func yIncrease(points []Point, rangeStartMsec, rangeEndMsec int64, isCounter bool) float64 {
-	log.Printf("yIncrease: range: %.3f...%.3f\n", float64(rangeStartMsec)/1000.0, float64(rangeEndMsec)/1000.0)
-	log.Println("yIncrease: samples: ", debugSampleString(points))
+//  Leaving these log lines here in case we'd like to use them again.
+// 	log.Printf("yIncrease: range: %.3f...%.3f\n", float64(rangeStartMsec)/1000.0, float64(rangeEndMsec)/1000.0)
+// 	log.Println("yIncrease: samples: ", debugSampleString(points))
 
 	lastBeforeRange := float64(0.0) // This provides the 0 counter fix for a fresh start of a pod.
 	if !isCounter && len(points) > 0 {
@@ -267,11 +267,10 @@ func yIncrease(points []Point, rangeStartMsec, rangeEndMsec int64, isCounter boo
 		lastValue = point.V
 	}
 
-	result := lastValue - lastBeforeRange + inRangeRestartSkew
+//  Leaving this log line here in case we'd like to use it again.
+// 	log.Printf("yIncrease: returning result: %.1f\n", result)
 
-	log.Printf("yIncrease: returning result: %.1f\n", result)
-
-	return result
+	return (lastValue - lastBeforeRange + inRangeRestartSkew)
 }
 
 // === delta(Matrix parser.ValueTypeMatrix) Vector ===

--- a/promql/functions.go
+++ b/promql/functions.go
@@ -246,7 +246,6 @@ func yIncrease(points []Point, rangeStartMsec, rangeEndMsec int64, isCounter boo
 	if !isCounter && len(points) > 0 {
 		lastBeforeRange = points[0].V // Gauges don't start at 0.
 	}
-	lastInRange := float64(0.0)
 
 	lastValue := float64(0.0)
 	inRangeRestartSkew := float64(0.0)
@@ -257,7 +256,6 @@ func yIncrease(points []Point, rangeStartMsec, rangeEndMsec int64, isCounter boo
 		if point.T >= rangeEndMsec { // Only consider points in [rangeStartMsec, rangeEndMsec).
 			break
 		}
-		lastInRange = point.V
 		if point.T >= rangeStartMsec {
 			if isCounter &&
 				point.V < lastValue { // If counter went backwards, it must have been a counter reset on process restart.
@@ -269,7 +267,7 @@ func yIncrease(points []Point, rangeStartMsec, rangeEndMsec int64, isCounter boo
 		lastValue = point.V
 	}
 
-	result := lastInRange - lastBeforeRange + inRangeRestartSkew
+	result := lastValue - lastBeforeRange + inRangeRestartSkew
 
 	log.Printf("yIncrease: returning result: %.1f\n", result)
 


### PR DESCRIPTION
The `lastInRange` value is redundant to `lastValue`, and by removing it I was able to see significant performance improvements when running the `bench_test.go`:

<details>
  <summary>


# Yrate Old
</summary>

```
BenchmarkRangeQuery/expr=yrate(a_one[1h]),steps=1-12        	   56229	     21123 ns/op	   25152 B/op	     187 allocs/op
BenchmarkRangeQuery/expr=yrate(a_one[1h]),steps=10-12       	   45560	     25054 ns/op	   25154 B/op	     187 allocs/op
BenchmarkRangeQuery/expr=yrate(a_one[1h]),steps=100-12      	   18744	     63534 ns/op	   25728 B/op	     192 allocs/op
BenchmarkRangeQuery/expr=yrate(a_one[1h]),steps=1000-12     	    2733	    459238 ns/op	   28650 B/op	     231 allocs/op
BenchmarkRangeQuery/expr=yrate(a_ten[1h]),steps=1-12        	    9026	    130511 ns/op	   42722 B/op	     471 allocs/op
BenchmarkRangeQuery/expr=yrate(a_ten[1h]),steps=10-12       	    7056	    168845 ns/op	   42700 B/op	     471 allocs/op
BenchmarkRangeQuery/expr=yrate(a_ten[1h]),steps=100-12      	    2144	    573474 ns/op	   45420 B/op	     512 allocs/op
BenchmarkRangeQuery/expr=yrate(a_ten[1h]),steps=1000-12     	     261	   4347225 ns/op	   66361 B/op	     851 allocs/op
BenchmarkRangeQuery/expr=yrate(a_hundred[1h]),steps=1-12    	    1020	   1167475 ns/op	  216727 B/op	    3270 allocs/op
BenchmarkRangeQuery/expr=yrate(a_hundred[1h]),steps=10-12   	     765	   1616422 ns/op	  216600 B/op	    3270 allocs/op
BenchmarkRangeQuery/expr=yrate(a_hundred[1h]),steps=100-12  	     210	   5657878 ns/op	  240746 B/op	    3671 allocs/op
BenchmarkRangeQuery/expr=yrate(a_hundred[1h]),steps=1000-12 	      25	  46485908 ns/op	  434446 B/op	    6873 allocs/op
```

</details>

<details>
<summary>

# Yrate without lastInRange variable
  </summary>

```
BenchmarkRangeQuery/expr=yrate(a_one[1h]),steps=1-12        	   56678	     20917 ns/op	   25156 B/op	     187 allocs/op
BenchmarkRangeQuery/expr=yrate(a_one[1h]),steps=10-12       	   48253	     24430 ns/op	   25149 B/op	     187 allocs/op
BenchmarkRangeQuery/expr=yrate(a_one[1h]),steps=100-12      	   20371	     58235 ns/op	   25692 B/op	     192 allocs/op
BenchmarkRangeQuery/expr=yrate(a_one[1h]),steps=1000-12     	    3051	    394467 ns/op	   28660 B/op	     231 allocs/op
BenchmarkRangeQuery/expr=yrate(a_ten[1h]),steps=1-12        	    9283	    124002 ns/op	   42731 B/op	     471 allocs/op
BenchmarkRangeQuery/expr=yrate(a_ten[1h]),steps=10-12       	    7370	    157232 ns/op	   42739 B/op	     471 allocs/op
BenchmarkRangeQuery/expr=yrate(a_ten[1h]),steps=100-12      	    2391	    494936 ns/op	   45439 B/op	     512 allocs/op
BenchmarkRangeQuery/expr=yrate(a_ten[1h]),steps=1000-12     	     313	   3811625 ns/op	   66358 B/op	     851 allocs/op
BenchmarkRangeQuery/expr=yrate(a_hundred[1h]),steps=1-12    	    1017	   1144133 ns/op	  216587 B/op	    3270 allocs/op
BenchmarkRangeQuery/expr=yrate(a_hundred[1h]),steps=10-12   	     783	   1478840 ns/op	  216688 B/op	    3270 allocs/op
BenchmarkRangeQuery/expr=yrate(a_hundred[1h]),steps=100-12  	     244	   4875852 ns/op	  241273 B/op	    3671 allocs/op
BenchmarkRangeQuery/expr=yrate(a_hundred[1h]),steps=1000-12 	      30	  38099921 ns/op	  433979 B/op	    6873 allocs/op
```
</details>