### PR TITLE
optimize yIncrease: omit duplicate var; use for with condition rather than range with break

### DIFF
--- a/promql/functions.go
+++ b/promql/functions.go
@@ -14,7 +14,6 @@
 package promql
 
 import (
-	"bytes"
 	"fmt"
 	"math"
 	"os"
@@ -207,25 +206,6 @@ func extendedRate(vals []parser.Value, args parser.Expressions, enh *EvalNodeHel
 	})
 }
 
-const elideSamplesAfter int = 10
-
-func debugSampleString(points []Point) string {
-	buffer := new(bytes.Buffer)
-	for i, point := range points {
-		if i == elideSamplesAfter && len(points)-1 > elideSamplesAfter {
-			fmt.Fprintf(buffer, "...")
-		} else if i > elideSamplesAfter && len(points)-i > elideSamplesAfter {
-			continue
-		} else {
-			if i > 0 {
-				fmt.Fprintf(buffer, ", ")
-			}
-			fmt.Fprintf(buffer, "[%.3f,%.1f]", float64(point.T)/1000.0, point.V)
-		}
-	}
-	return buffer.String()
-}
-
 // yIncrease is a utility function for yincrease/yrate/ydelta.
 // It calculates the increase of the range (allowing for counter resets),
 // taking into account the sample at the end of the previous range (just before rangeStartMsec).
@@ -238,9 +218,6 @@ func debugSampleString(points []Point) string {
 //
 //	yIncrease(p0) + yIncrease(p1) == yIncrease(p0 + p1)
 func yIncrease(points []Point, rangeStartMsec, rangeEndMsec int64, isCounter bool) float64 {
-	// log.Printf("yIncrease: range: %.3f...%.3f\n", float64(rangeStartMsec)/1000.0, float64(rangeEndMsec)/1000.0)
-	// log.Println("yIncrease: samples: ", debugSampleString(points))
-	
 	var lastBeforeRange, lastInRange, inRangeRestartSkew float64
 
 	if !isCounter && len(points) > 0 {

--- a/promql/functions.go
+++ b/promql/functions.go
@@ -16,7 +16,6 @@ package promql
 import (
 	"bytes"
 	"fmt"
-	"log"
 	"math"
 	"os"
 	"sort"
@@ -239,41 +238,31 @@ func debugSampleString(points []Point) string {
 //
 //	yIncrease(p0) + yIncrease(p1) == yIncrease(p0 + p1)
 func yIncrease(points []Point, rangeStartMsec, rangeEndMsec int64, isCounter bool) float64 {
-	log.Printf("yIncrease: range: %.3f...%.3f\n", float64(rangeStartMsec)/1000.0, float64(rangeEndMsec)/1000.0)
-	log.Println("yIncrease: samples: ", debugSampleString(points))
+	// log.Printf("yIncrease: range: %.3f...%.3f\n", float64(rangeStartMsec)/1000.0, float64(rangeEndMsec)/1000.0)
+	// log.Println("yIncrease: samples: ", debugSampleString(points))
+	
+	var lastBeforeRange, lastInRange, inRangeRestartSkew float64
 
-	lastBeforeRange := float64(0.0) // This provides the 0 counter fix for a fresh start of a pod.
 	if !isCounter && len(points) > 0 {
 		lastBeforeRange = points[0].V // Gauges don't start at 0.
 	}
-	lastInRange := float64(0.0)
-
-	lastValue := float64(0.0)
-	inRangeRestartSkew := float64(0.0)
 
 	// The points are in time order, so we can just walk the list once and remember the last values
-	// seen "before" and "in" range. If there are no values in range, we use the last value before range.
-	for _, point := range points {
-		if point.T >= rangeEndMsec { // Only consider points in [rangeStartMsec, rangeEndMsec).
-			break
-		}
-		lastInRange = point.V
-		if point.T >= rangeStartMsec {
+	// seen "before" and "in" range. If there are no values in range, we use the last value before range
+	// so that the increase is 0.
+	for i := 0; i < len(points) && points[i].T < rangeEndMsec; i++ { // Only consider points in [rangeStartMsec, rangeEndMsec).
+		if points[i].T >= rangeStartMsec {
 			if isCounter &&
-				point.V < lastValue { // If counter went backwards, it must have been a counter reset on process restart.
-				inRangeRestartSkew += lastValue
+				points[i].V < lastInRange { // If counter went backwards, it must have been a counter reset on process restart.
+				inRangeRestartSkew += lastInRange
 			}
 		} else {
-			lastBeforeRange = point.V
+			lastBeforeRange = points[i].V
 		}
-		lastValue = point.V
+		lastInRange = points[i].V
 	}
 
-	result := lastInRange - lastBeforeRange + inRangeRestartSkew
-
-	log.Printf("yIncrease: returning result: %.1f\n", result)
-
-	return result
+	return lastInRange - lastBeforeRange + inRangeRestartSkew
 }
 
 // === delta(Matrix parser.ValueTypeMatrix) Vector ===


### PR DESCRIPTION
@ttstarck found that `yincrease` performance was much worse than `increase` and even worse than `xincrease`. I think likely the biggest reason was the logging. But also through benchmarking, Tristan found that `break` was a bit slower, and there was a duplicate variable we didn't need. Also `range` makes a copy that wasn't really necessary (also the other code we're comparing to also paid the cost of that `range` copy).

I do like how this version of the code has the main loop covered entirely by `for` rather than a combination of `range` + `break`.

Optimize `yIncrease`. Omit duplicate variable. Use `for` with condition rather than `range` with `break`.
