### PR TITLE
Add Backstage catalog-info.yaml

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -14,4 +14,4 @@ spec:
   type: tool
   lifecycle: production
   owner: sre-core
-  # system: TODO — see https://github.com/Invoca/backstage-catalog
+  system: platform-observability

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,17 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: prometheus
+  title: prometheus
+  description: "The Prometheus monitoring system and time series database."
+  tags:
+    - go
+  annotations:
+    backstage.io/source-location: url:https://github.com/Invoca/prometheus/
+    github.com/project-slug: Invoca/prometheus
+    buildkite.com/project-slug: invoca/prometheus
+spec:
+  type: tool
+  lifecycle: production
+  owner: sre-core
+  # system: TODO — see https://github.com/Invoca/backstage-catalog


### PR DESCRIPTION
## Add Backstage `catalog-info.yaml`

Registers this repo in the [Invoca Backstage catalog](https://backstage.invoca.net).

### What was auto-generated
- **type**: `tool` (inferred from repo name/language)
- **owner**: `sre-core`
- **system**: `platform-observability`

### Please review before merging
- [ ] `spec.owner` is correct
- [ ] `spec.system` is set (see [taxonomy](https://github.com/Invoca/backstage-catalog))
- [ ] `metadata.description` is accurate
- [ ] Add `dependsOn`, `providesApis`, or `consumesApis` if relevant

See [voice-agent](https://github.com/Invoca/voice-agent/tree/main/.backstage) for a fully-built example.

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)
