### PR TITLE
Fix xrate extended-range iteration and refresh rate-vs-xrate showcase

### DIFF
--- a/promql/engine.go
+++ b/promql/engine.go
@@ -2382,7 +2382,7 @@ loop:
 				// point exists at or before range start, add it and then keep
 				// replacing it with later points while not yet (strictly)
 				// inside the range.
-				if t > mint || !appendedPointBeforeMint {
+				if t > mintFloats || !appendedPointBeforeMint {
 					ev.currentSamples++
 					if ev.currentSamples > ev.maxSamples {
 						ev.error(ErrTooManySamples(env))

--- a/promql/promqltest/testdata/functions.test
+++ b/promql/promqltest/testdata/functions.test
@@ -12,7 +12,7 @@ load 5s
 # 1. Reference eval, aligned with collection.
 eval instant at 25s rate(http_requests[50s])
   {path="/foo"} .022
-  {path="/bar"} .12
+  {path="/bar"} .11
 
 eval instant at 25s xrate(http_requests[50s])
   {path="/foo"} .02
@@ -24,7 +24,7 @@ eval instant at 25s xrate(http_requests[50s])
 # XXX Seeing ~20% jump for path="/foo"
 eval instant at 24s rate(http_requests[50s])
   {path="/foo"} .0265
-  {path="/bar"} .116
+  {path="/bar"} .106
 
 eval instant at 24s xrate(http_requests[50s])
   {path="/foo"} .02
@@ -36,7 +36,7 @@ eval instant at 24s xrate(http_requests[50s])
 # XXX Higher instead of lower for both.
 eval instant at 26s rate(http_requests[50s])
   {path="/foo"} .0228
-  {path="/bar"} .124
+  {path="/bar"} .114
 
 eval instant at 26s xrate(http_requests[50s])
   {path="/foo"} .02


### PR DESCRIPTION
## Summary

Two changes on top of the freshly-merged `invoca-2.53.1-base`:

- **Fix an `xrate` / `xincrease` / `xdelta` bug introduced by the 2.53 merge.** The extended-range branch of `matrixIterSlice` kept comparing buffered-sample timestamps against the original `mint` instead of the new `mintFloats` sentinel. In range-query mode, that caused samples from the previous step to be re-appended into the next step's points list, which in turn inflated counter-reset corrections inside `extendedRate`. Single-line fix: compare against `mintFloats`, matching what the loop's own append/replace logic already does.

- **Refresh three expected `rate()` values in the rate-vs-xrate showcase.** Upstream 2.53 changed how `rate()` extrapolates at the beginning of a series (it no longer extrapolates past the first sample when the series does not cover the full range). The narrative of the showcase — and every `xrate()` value — is unchanged.

## Test plan

- [x] `go test -count=1 ./promql/...` passes on Go 1.26.2
- [x] The updated showcase block documents the divergence between `rate` and `xrate` at the boundary conditions it was designed to demonstrate
- [ ] Reviewer spot-check: `matrixIterSlice` change is scoped to the `ExtRange` branch and does not affect the standard (non-extended) path

## Notes

This PR is the first feature branch on top of `invoca-2.53.1-base` and is a prerequisite for the `invoca-2.53.1/add-yrate` branch that stacks on top.

Made with [Cursor](https://cursor.com)