### PR TITLE
Fix xrate extended-range iteration and refresh rate-vs-xrate showcase (2.55)

### DIFF
--- a/promql/engine.go
+++ b/promql/engine.go
@@ -2438,7 +2438,7 @@ loop:
 				// point exists at or before range start, add it and then keep
 				// replacing it with later points while not yet (strictly)
 				// inside the range.
-				if t > mint || !appendedPointBeforeMint {
+				if t > mintFloats || !appendedPointBeforeMint {
 					ev.currentSamples++
 					if ev.currentSamples > ev.maxSamples {
 						ev.error(ErrTooManySamples(env))

--- a/promql/promqltest/testdata/functions.test
+++ b/promql/promqltest/testdata/functions.test
@@ -12,7 +12,7 @@ load 5s
 # 1. Reference eval, aligned with collection.
 eval instant at 25s rate(http_requests[50s])
   {path="/foo"} .022
-  {path="/bar"} .12
+  {path="/bar"} .11
 
 eval instant at 25s xrate(http_requests[50s])
   {path="/foo"} .02
@@ -24,7 +24,7 @@ eval instant at 25s xrate(http_requests[50s])
 # XXX Seeing ~20% jump for path="/foo"
 eval instant at 24s rate(http_requests[50s])
   {path="/foo"} .0265
-  {path="/bar"} .116
+  {path="/bar"} .106
 
 eval instant at 24s xrate(http_requests[50s])
   {path="/foo"} .02
@@ -36,7 +36,7 @@ eval instant at 24s xrate(http_requests[50s])
 # XXX Higher instead of lower for both.
 eval instant at 26s rate(http_requests[50s])
   {path="/foo"} .0228
-  {path="/bar"} .124
+  {path="/bar"} .114
 
 eval instant at 26s xrate(http_requests[50s])
   {path="/foo"} .02


### PR DESCRIPTION
## Summary

Forward-port of #16 onto `invoca-2.55.1-base`.

Cherry-picked cleanly from `invoca-2.53.1/fix-xrate-extended-range` (one commit, auto-merged in both `promql/engine.go` and `promql/promqltest/testdata/functions.test`). No code changes from the 2.53.1 version — the 2.53→2.55 upstream delta does not touch the lines involved.

- Fixes the `mintFloats` vs `mint` off-by-one in the extended-range branch of `matrixIterSlice` that re-appended previous-step samples into the next step's points list (inflated counter-reset corrections for `xrate` / `xincrease` / `xdelta` in range-query mode).
- Refreshes the three `rate()` showcase expected values to match upstream's 2.53+ extrapolation behaviour (same three values we updated on 2.53.1).

## Test plan

- [x] `go test -count=1 ./promql/...` passes on Go 1.26.2
- [x] Single commit matches #16 semantically (same diff modulo surrounding upstream context)

## Related

- Stacked on `invoca-2.55.1-base` (merge of upstream v2.55.1 into `invoca-2.53.1-base`).
- Equivalent branch on 2.53.1: #16.
- `invoca-2.55.1/add-yrate` stacks on top of this.

