### PR TITLE
[internal review, not for upstream yet] docs: state the anchored additivity invariant

### DIFF
--- a/docs/feature_flags.md
+++ b/docs/feature_flags.md
@@ -353,6 +353,16 @@ Example query:
 
 **Note**: When using the anchored modifier with the increase function, the results returned are integers.
 
+**Composability (additive property)**: With `anchored`, `increase`, `rate`, and `delta` are *additive* over adjacent ranges. For any series `m` and timestamps `T₀ < T₁ < T₂` with `r₁ = T₁ − T₀` (≤ lookback delta) and `r₂ = T₂ − T₁`:
+
+```
+  increase(m[r₁]      anchored)  @ T₁
++ increase(m[r₂]      anchored)  @ T₂
+= increase(m[r₁ + r₂] anchored)  @ T₂
+```
+
+This invariant is what makes anchored `increase` composable: splitting a wider range into adjacent sub-ranges and summing the results gives the same answer as asking for the wider range directly — and it does this for any possible sub-ranges. See [#18679](https://github.com/prometheus/prometheus/issues/18679) for the precise statement and proposed invariant tests.
+
 ### `smoothed`
 
 In range selectors, linearly interpolates values at the range boundaries, using the sample values before and after the boundaries for an improved estimation that is robust against irregular scrapes and missing samples. However, it requires a sample after the evaluation interval to work properly, see note below.


### PR DESCRIPTION
## Internal-review draft

This is the first of two upstream-bound PRs that follow up on [prometheus/prometheus#18679](https://github.com/prometheus/prometheus/issues/18679). It is filed against `Invoca/prometheus:prom-18679/upstream-snapshot` (a pinned mirror of `prometheus/prometheus@e793b2671`) so the diff shows *only* the proposed upstream change. **Do not push this branch upstream until we've reviewed.**

The companion proposal-text amendment is here: [Invoca/proposals#1](https://github.com/Invoca/proposals/pull/1).

## What this changes

`docs/feature_flags.md`, inside the `### anchored` subsection: appends a short callout that states the additive property of `anchored`-mode `increase` / `rate` / `delta`. The callout points at upstream issue #18679 for the precise statement and proposed tests.

Rendered preview: [docs/feature_flags.md on this branch](https://github.com/Invoca/prometheus/blob/prom-18679/feature-flags-callout/docs/feature_flags.md#anchored)

## Why

- The proposal already lists "Improved composability across range boundaries" as a use case (proposal 0052, line 222), but neither the proposal nor the user-facing docs say what *exactly* "composable" means.
- We've run `yincrease` / `yrate` / `ydelta` in production for ~3 years and the additive property is *the* reason it stays predictable and explainable under irregular scrapes, with no partition-boundary surprises. Putting it in writing here in feature-flag doc makes the guarantee discoverable.
- Sets up the proposal-amendment PR to anchor on a one-line invariant rather than re-deriving it.

## Review checklist

- [ ] Math reads cleanly in GitHub's Markdown render (Unicode subscripts on `T₀ T₁ T₂`, `r₁ r₂`)
- [ ] Wording matches the issue body at #18679
- [ ] No accidental edits outside the `anchored` block
- [ ] Tone fits the surrounding feature-flag entries (we keep it short and link out rather than restating the invariant here)

## Once approved

- Retarget base to `prometheus/prometheus:main`
- Convert from draft to ready-for-review
- Cross-reference from the upstream issue thread


